### PR TITLE
ENG-39042 improve salesforce client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /checkouts
 pom.xml
 pom.xml.asc
+repl-files/
 *.jar
 *.class
 .lein*

--- a/project.clj
+++ b/project.clj
@@ -8,4 +8,9 @@
                  [cheshire "5.8.1"]]
 
   :plugins [[lein-cljfmt "0.6.4"]
-            [lein-ancient "0.6.15"]]) ; For detecting and fixing outdated dependencies. See https://github.com/xsc/lein-ancient
+            [lein-ancient "0.6.15"]] ; lein-ancient is for detecting and fixing outdated dependencies. See https://github.com/xsc/lein-ancient
+
+  :profiles
+
+  {:test         {:dependencies [[clj-http-fake "1.0.3"]]
+                 :resource-paths ["env/test/resources"]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.flexport-clojure-eng/salesforce "1.0.4"
+(defproject org.clojars.flexport-clojure-eng/salesforce "1.0.5"
   :description "A clojure library for accessing the salesforce api"
   :url "https://www.flexport.com"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.flexport-clojure-eng/salesforce "1.0.5"
+(defproject org.clojars.flexport-clojure-eng/salesforce "2.0.1-SNAPSHOT"
   :description "A clojure library for accessing the salesforce api"
   :url "https://www.flexport.com"
   :license {:name "Eclipse Public License"

--- a/script/format
+++ b/script/format
@@ -1,0 +1,5 @@
+#! /usr/bin/env sh
+
+# Convenience script for formatting the code
+
+lein cljfmt fix

--- a/script/install-jar-locally
+++ b/script/install-jar-locally
@@ -1,0 +1,6 @@
+#! /usr/bin/env sh
+
+# Convenience script for installing the jar to the local maven repository (typically under `~/.m2`)
+# Doing this is helpful for using unpublished versions of the jar in other projects during development.
+
+lein install

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -31,14 +31,14 @@
    - security-token TOKEN
   http-client-config-map is a (potentially empty) map of options accepted by clj-http/core/request,
   including keys such as: connection-timeout connection-request-timeout connection-manager"
-  [{:keys [client-id client-secret username password security-token] :as app_data} http-client-config-map]
-  (let [params {:grant_type "password"
-                :client_id client-id ; note conversion of hyphen to underscore in key name
-                :client_secret client-secret ; note conversion of hyphen to underscore in key name
-                :username username
-                :password (str password security-token)
-                :format "json"}
-        all-params (merge {:form-params params} (or http-client-config-map {}))]
+  [{:keys [client-id client-secret username password security-token] :as app_data} & [http-client-config-map]]
+  (let [salesforce-params {:grant_type "password"
+                           :client_id client-id ; note conversion of hyphen to underscore in key name
+                           :client_secret client-secret ; note conversion of hyphen to underscore in key name
+                           :username username
+                           :password (str password security-token)
+                           :format "json"}
+        all-params (merge {:form-params salesforce-params} (or http-client-config-map {}))]
     all-params))
 
 (defn auth!
@@ -52,7 +52,7 @@
    - login-host HOSTNAME (default login.salesforce.com)
    http-client-config-map is an optional map of options accepted by clj-http/core/request, such as keys: connection-timeout connection-request-timeout connection-manager
    "
-  [[{:keys [login-host] :as app_data} & [http-client-config-map]]]
+  [{:keys [login-host] :as app_data} & [http-client-config-map]]
   (let [hostname (or login-host "login.salesforce.com")
         auth-url (format "https://%s/services/oauth2/token" hostname)
         all-params (make-params-for-auth-request app_data http-client-config-map)

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -49,7 +49,7 @@
    - username USERNAME
    - password PASSWORD
    - security-token TOKEN
-   - login-host HOSTNAME (default login.salesforce.com
+   - login-host HOSTNAME (default login.salesforce.com)
    http-client-config-map is a map of options accepted by clj-http/core/request, including keys: connection-timeout connection-request-timeout connection-manager
    "
   [[{:keys [login-host] :as app_data} http-client-config-map]]

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -54,6 +54,7 @@
 (defn- perform-request [client-params]
   "Part 2 of 2 of replacement of 'request' - An impure function that uses output of 'prepare-request to make actual http call via clj-http"
   (let [resp (http/request client-params)]
+    ; TODO The limit reading code does not seem to be working; at least (read-limit-info) only returns {} after making a couple of soql calls. Extract to its own function and fix.
     (some-> (get-in resp [:headers "sforce-limit-info"]) ;; Record limit info in atom, if available (does not seem to be provided in auth responses.)
             (parse-limit-info)
             (partial reset! limit-info))

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -101,7 +101,9 @@
         (json/decode true))))
 
 (defn- request
-  "Make a HTTP request to the Salesforce.com REST API
+  "DEPRECATED. Use the combination of `prepare-request` and `peform-request` instead.
+   Make a HTTP request to the Salesforce.com REST API
+   Make a HTTP request to the Salesforce.com REST API
    Token is the full map returned from (auth! @conf)"
   [method url token & [params]]
   (let [base-url (:instance_url token)

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -327,7 +327,7 @@
   [query token & [http-client-config]]
   (prepare-authorized-request :get (gen-query-url @+version+ query) token http-client-config))
 
-(defn soql!
+(defn soql
   "Executes an arbitrary SOQL query
    i.e SELECT name from Account
    http-client-config is an optional map of options accepted by clj-http/core/request, such as keys: connection-timeout connection-request-timeout connection-manager

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -21,26 +21,6 @@
          (with-open [r (clojure.java.io/reader f)]
            (read (java.io.PushbackReader. r))))))
 
-(defn make-params-for-auth-request
-  "Prepare params map for clj_http post call
-  app_data is a map in the form
-   - client-id ID
-   - client-secret SECRET
-   - username USERNAME
-   - password PASSWORD
-   - security-token TOKEN
-  http-client-config-map is a (potentially empty) map of options accepted by clj-http/core/request,
-  including keys such as: connection-timeout connection-request-timeout connection-manager"
-  [{:keys [client-id client-secret username password security-token] :as app_data} & [http-client-config-map]]
-  (let [salesforce-params {:grant_type "password"
-                           :client_id client-id ; note conversion of hyphen to underscore in key name
-                           :client_secret client-secret ; note conversion of hyphen to underscore in key name
-                           :username username
-                           :password (str password security-token)
-                           :format "json"}
-        all-params (merge {:form-params salesforce-params} (or http-client-config-map {}))]
-    all-params))
-
 (def ^:private limit-info (atom {}))
 
 (defn- parse-limit-info [v]

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -50,9 +50,9 @@
    - password PASSWORD
    - security-token TOKEN
    - login-host HOSTNAME (default login.salesforce.com)
-   http-client-config-map is a map of options accepted by clj-http/core/request, including keys: connection-timeout connection-request-timeout connection-manager
+   http-client-config-map is an optional map of options accepted by clj-http/core/request, including keys: connection-timeout connection-request-timeout connection-manager
    "
-  [[{:keys [login-host] :as app_data} http-client-config-map]]
+  [[{:keys [login-host] :as app_data} & [http-client-config-map]]]
   (let [hostname (or login-host "login.salesforce.com")
         auth-url (format "https://%s/services/oauth2/token" hostname)
         all-params (make-params-for-auth-request app_data http-client-config-map)

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -31,7 +31,7 @@
    - security-token TOKEN
   http-client-config-map is a (potentially empty) map of options accepted by clj-http/core/request,
   including keys such as: connection-timeout connection-request-timeout connection-manager"
-  [{:keys [client-id client-secret username password security-token login-host] :as app_data} http-client-config-map]
+  [{:keys [client-id client-secret username password security-token] :as app_data} http-client-config-map]
   (let [params {:grant_type "password"
                 :client_id client-id ; note conversion of hyphen to underscore in key name
                 :client_secret client-secret ; note conversion of hyphen to underscore in key name

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -276,7 +276,7 @@
 (defn ^:private gen-query-url
   "Given an SOQL string, i.e \"SELECT name from Account\"
    generate a Salesforce SOQL query url in the form:
-   /services/data/v20.0/query/?q=SELECT+name+from+Account"
+   /services/data/v39.0/query?q=SELECT+name+from+Account"
   [version query]
   (let [url  (format "/services/data/v%s/query" version)
         soql (java.net.URLEncoder/encode query "UTF-8")]

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -115,9 +115,9 @@
   - password PASSWORD
   - security-token TOKEN
   - login-host HOSTNAME (optional; default login.salesforce.com)
-  http-client-config-map is an optional map of options accepted by clj-http/core/request, such as keys: connection-timeout connection-request-timeout connection-manager
+  http-client-config is an optional map of options accepted by clj-http/core/request, such as keys: connection-timeout connection-request-timeout connection-manager
   "
-  [{:keys [client-id client-secret username password security-token login-host] :as app_data} & [http-client-config-map]]
+  [{:keys [client-id client-secret username password security-token login-host] :as app_data} & [http-client-config]]
   (let [hostname (or login-host "login.salesforce.com")
         auth-url (format "https://%s/services/oauth2/token" hostname)
         salesforce-params {:grant_type "password"
@@ -126,7 +126,7 @@
                            :username username
                            :password (str password security-token)
                            :format "json"}
-        client-params (merge (or http-client-config-map {})
+        client-params (merge (or http-client-config {})
                              {:form-params salesforce-params}
                              {:method :post :url auth-url})]
     client-params))
@@ -140,10 +140,10 @@
    - password PASSWORD
    - security-token TOKEN
    - login-host HOSTNAME (default login.salesforce.com)
-   http-client-config-map is an optional map of options accepted by clj-http/core/request, such as keys: connection-timeout connection-request-timeout connection-manager
+   http-client-config is an optional map of options accepted by clj-http/core/request, such as keys: connection-timeout connection-request-timeout connection-manager
    "
-  [app_data & [http-client-config-map]]
-  (-> (auth-prepare app_data http-client-config-map)
+  [app_data & [http-client-config]]
+  (-> (auth-prepare app_data http-client-config)
       (perform-request)))
 
 ;; Salesforce API version information
@@ -303,14 +303,14 @@
 (defn soql-prepare
   "Prepares params for http client to execute an arbitrary SOQL query
    i.e SELECT name from Account
-   http-client-config-map is an optional map of options accepted by clj-http/core/request, such as keys: connection-timeout connection-request-timeout connection-manager"
-  [query token & [http-client-config-map]]
-  (prepare-request :get (gen-query-url @+version+ query) token http-client-config-map))
+   http-client-config is an optional map of options accepted by clj-http/core/request, such as keys: connection-timeout connection-request-timeout connection-manager"
+  [query token & [http-client-config]]
+  (prepare-request :get (gen-query-url @+version+ query) token http-client-config))
 
 (defn soql!
   "Executes an arbitrary SOQL query
    i.e SELECT name from Account
-   http-client-config-map is an optional map of options accepted by clj-http/core/request, such as keys: connection-timeout connection-request-timeout connection-manager"
-  [query token & [http-client-config-map]]
-  (-> (soql-prepare query token http-client-config-map)
+   http-client-config is an optional map of options accepted by clj-http/core/request, such as keys: connection-timeout connection-request-timeout connection-manager"
+  [query token & [http-client-config]]
+  (-> (soql-prepare query token http-client-config)
       (perform-request)))

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -317,8 +317,8 @@
    /services/data/v39.0/query?q=SELECT+name+from+Account"
   [version query]
   (let [url  (format "/services/data/v%s/query" version)
-        soql (java.net.URLEncoder/encode query "UTF-8")]
-    (apply str [url "?q=" soql])))
+        query (java.net.URLEncoder/encode query "UTF-8")]
+    (apply str [url "?q=" query])))
 
 (defn soql-prepare
   "Prepares params for http client to execute an arbitrary SOQL query

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -285,7 +285,7 @@
     (apply str [url "?q=" soql])))
 
 (defn soql-prepare
-  "Prepares params to execute an arbitrary SOQL query
+  "Prepares params for http client to execute an arbitrary SOQL query
    i.e SELECT name from Account
    http-client-config-map is an optional map of options accepted by clj-http/core/request, such as keys: connection-timeout connection-request-timeout connection-manager"
   [query token & [http-client-config-map]]

--- a/src/salesforce/core.clj
+++ b/src/salesforce/core.clj
@@ -12,15 +12,16 @@
   `(binding [+token+ ~token]
      (do ~@forms)))
 
-(defn-  as-json
+(defn- as-json
   "Takes a Clojure map and returns a JSON string"
   [map]
   (json/generate-string map))
 
-(defn conf [f]
-  (ref (binding [*read-eval* false]
-         (with-open [r (clojure.java.io/reader f)]
-           (read (java.io.PushbackReader. r))))))
+(comment
+  (defn conf [f]
+    (ref (binding [*read-eval* false]
+           (with-open [r (clojure.java.io/reader f)]
+             (read (java.io.PushbackReader. r)))))))
 
 (def ^:private limit-info (atom {}))
 
@@ -190,41 +191,46 @@
 
 ;; Resources
 
-(defn resources [token]
-  (request :get (format "/services/data/v%s/" @+version+) token))
+(comment
+  (defn resources [token]
+    (request :get (format "/services/data/v%s/" @+version+) token)))
 
-(defn so->objects
-  "Lists all of the available sobjects"
-  [token]
-  (request :get (format "/services/data/v%s/sobjects" @+version+) token))
+(comment
+  (defn so->objects
+    "Lists all of the available sobjects"
+    [token]
+    (request :get (format "/services/data/v%s/sobjects" @+version+) token)))
 
-(defn so->all
-  "All sobjects i.e (so->all \"Account\" auth-info)"
-  [sobject token]
-  (request :get (format "/services/data/v%s/sobjects/%s" @+version+ sobject) token))
+(comment
+  (defn so->all
+    "All sobjects i.e (so->all \"Account\" auth-info)"
+    [sobject token]
+    (request :get (format "/services/data/v%s/sobjects/%s" @+version+ sobject) token)))
 
-(defn so->recent
-  "The recently created items under an sobject identifier
-   e.g (so->recent \"Account\" auth-info)"
-  [sobject token]
-  (:recentItems (so->all sobject token)))
+(comment
+  (defn so->recent
+    "The recently created items under an sobject identifier
+     e.g (so->recent \"Account\" auth-info)"
+    [sobject token]
+    (:recentItems (so->all sobject token))))
 
-(defn so->get
-  "Fetch a single SObject or passing in a vector of attributes
+(comment
+  (defn so->get
+    "Fetch a single SObject or passing in a vector of attributes
    return a subset of the data"
-  ([sobject identifier fields token]
-   (when (or (seq? fields) (vector? fields))
-     (let [params (->> (into [] (interpose "," fields))
-                       (str/join)
-                       (conj ["?fields="])
-                       (apply str))
-           uri (format "/services/data/v%s/sobjects/%s/%s%s"
-                       @+version+ sobject identifier params)
-           response (request :get uri token)]
-       (dissoc response :attributes))))
-  ([sobject identifier token]
-   (request :get
-            (format "/services/data/v%s/sobjects/%s/%s" @+version+ sobject identifier) token)))
+    ([sobject identifier fields token]
+     (when (or (seq? fields) (vector? fields))
+       (let [params (->> (into [] (interpose "," fields))
+                         (str/join)
+                         (conj ["?fields="])
+                         (apply str))
+             uri (format "/services/data/v%s/sobjects/%s/%s%s"
+                         @+version+ sobject identifier params)
+             response (request :get uri token)]
+         (dissoc response :attributes))))
+    ([sobject identifier token]
+     (request :get
+              (format "/services/data/v%s/sobjects/%s/%s" @+version+ sobject identifier) token))))
 
 (comment
   ;; Fetch all the info
@@ -232,66 +238,71 @@
   ;; Fetch only the name and website attribute
   (so->get "Account" "001i0000007nAs3" ["Name" "Website"] auth))
 
-(defn so->describe
-  "Describe an SObject"
-  [sobject token]
-  (request :get
-           (format "/services/data/v%s/sobjects/%s/describe" @+version+ sobject) token))
+(comment
+  (defn so->describe
+    "Describe an SObject"
+    [sobject token]
+    (request :get
+             (format "/services/data/v%s/sobjects/%s/describe" @+version+ sobject) token)))
 
 (comment
   (so->describe "Account" auth))
 
-(defn so->create
-  "Create a new record"
-  [sobject record token]
-  (let [params
-        {:form-params record
-         :content-type :json}]
-    (request :post
-             (format "/services/data/v%s/sobjects/%s/" @+version+ sobject) token params)))
+(comment
+  (defn so->create
+    "Create a new record"
+    [sobject record token]
+    (let [params
+          {:form-params record
+           :content-type :json}]
+      (request :post
+               (format "/services/data/v%s/sobjects/%s/" @+version+ sobject) token params))))
 
 (comment
   (so->create "Account" {:Name "My new account"} auth))
 
-(defn so->update
-  "Update a record
-   - sojbect the name of the object i.e Account
-   - identifier the object id
-   - record map of data to update object with
-   - token your api auth info"
-  [sobject identifier record token]
-  (let [params
-        {:body (json/generate-string record)
-         :content-type :json}]
-    (request :patch
-             (format "/services/data/v%s/sobjects/%s/%s" @+version+ sobject identifier)
-             token params)))
+(comment
+  (defn so->update
+    "Update a record
+     - sojbect the name of the object i.e Account
+     - identifier the object id
+     - record map of data to update object with
+     - token your api auth info"
+    [sobject identifier record token]
+    (let [params
+          {:body (json/generate-string record)
+           :content-type :json}]
+      (request :patch
+               (format "/services/data/v%s/sobjects/%s/%s" @+version+ sobject identifier)
+               token params))))
 
-(defn so->delete
-  "Delete a record
-   - sojbect the name of the object i.e Account
-   - identifier the object id
-   - token your api auth info"
-  [sobject identifier token]
-  (request :delete
-           (format "/services/data/v%s/sobjects/%s/%s" @+version+ sobject identifier)
-           token))
+(comment
+  (defn so->delete
+    "Delete a record
+     - sojbect the name of the object i.e Account
+     - identifier the object id
+     - token your api auth info"
+    [sobject identifier token]
+    (request :delete
+             (format "/services/data/v%s/sobjects/%s/%s" @+version+ sobject identifier)
+             token)))
 
 (comment
   (so->delete "Account" "001i0000008Ge2OAAS" auth))
 
-(defn so->flow
-  "Invoke a flow (see: https://developer.salesforce.com/docs/atlas.en-us.salesforce_vpm_guide.meta/salesforce_vpm_guide/vpm_distribute_system_rest.htm)
-  - indentifier of flow (e.g. \"Escalate_to_Case\")
-  - inputs map (e.g. {:inputs [{\"CommentCount\" 6
-                                \"FeedItemId\" \"0D5D0000000cfMY\"}]})
-  - token to your api auth info"
-  [identifier token & [data]]
-  (let [params {:body (json/generate-string (or data {:inputs []}))
-                :content-type :json}]
-    (request :post
-             (format "/services/data/v%s/actions/custom/flow/%s" @+version+ identifier)
-             token params)))
+(comment
+  (defn so->flow
+    "Invoke a flow (see: https://developer.salesforce.com/docs/atlas.en-us.salesforce_vpm_guide.meta/salesforce_vpm_guide/vpm_distribute_system_rest.htm)
+    - indentifier of flow (e.g. \"Escalate_to_Case\")
+    - inputs map (e.g. {:inputs [{\"CommentCount\" 6
+                                  \"FeedItemId\" \"0D5D0000000cfMY\"}]})
+    - token to your api auth info"
+    [identifier token & [data]]
+    (let [params {:body (json/generate-string (or data {:inputs []}))
+                  :content-type :json}]
+      (request :post
+               (format "/services/data/v%s/actions/custom/flow/%s" @+version+ identifier)
+               token params))))
 
 (comment
   (so->flow "Escalate_to_Case" a {:inputs [{"CommentCount" 6

--- a/test/salesforce/core_test.clj
+++ b/test/salesforce/core_test.clj
@@ -8,15 +8,64 @@
      ~@tests))
 
 (def sample-auth
-  {:id "https://login.salesforce.com/id/1234",
-   :issued_at "1367488271359",
+  {:id           "https://login.salesforce.com/id/1234",
+   :issued_at    "1367488271359",
    :instance_url "https://na15.salesforce.com",
-   :signature "SIG",
+   :signature    "SIG",
    :access_token "ACCESS"})
 
 (deftest with-version-test
   (testing "should set +version+ to a given string"
     (is (= "26.0" (with-version "26.0" @+version+)))))
+
+(def well-formed-auth-app-data
+  {:client-id      "my-ID"
+   :client-secret  "my-SECRET"
+   :username       "my-USERNAME"
+   :password       "my-PASSWORD"
+   :security-token "my-TOKEN"})
+
+(def well-formed-client-config-empty {})
+
+(testing "make-params-for-auth-request"
+  (testing "accepts nil 2nd arg"
+    (is
+     (=
+      {:form-params {:grant_type    "password"
+                     :client_id     "my-ID"
+                     :client_secret "my-SECRET"
+                     :format         "json",
+                     :username      "my-USERNAME"
+                     :password      "my-PASSWORDmy-TOKEN"}}
+      (make-params-for-auth-request well-formed-auth-app-data nil))))
+
+  (testing "accepts empty 2nd arg"
+    (is
+     (=
+      {:form-params {:grant_type "password"
+                     :client_id     "my-ID"
+                     :client_secret "my-SECRET"
+                     :format         "json",
+                     :username      "my-USERNAME"
+                     :password      "my-PASSWORDmy-TOKEN"}}
+      (make-params-for-auth-request well-formed-auth-app-data {}))))
+
+  (testing "includes all keys from 2nd arg when provided"
+    (is
+     (=
+      {:form-params                {:grant_type "password"
+                                    :client_id     "my-ID"
+                                    :client_secret "my-SECRET"
+                                    :format         "json",
+                                    :username      "my-USERNAME"
+                                    :password      "my-PASSWORDmy-TOKEN"}
+       :connection-timeout         10
+       :connection-request-timeout 10
+       :foo                        5}
+      (make-params-for-auth-request well-formed-auth-app-data
+                                    {:connection-timeout 10 :connection-request-timeout 10 :foo 5})))))
+
+()
 
 ;; Private functions
 

--- a/test/salesforce/core_test.clj
+++ b/test/salesforce/core_test.clj
@@ -27,7 +27,7 @@
 
 (def well-formed-client-config-empty {})
 
-(testing "make-params-for-auth-request"
+(deftest test-make-params-for-auth-request
   (testing "accepts nil 2nd arg"
     (is
      (=

--- a/test/salesforce/core_test.clj
+++ b/test/salesforce/core_test.clj
@@ -7,13 +7,6 @@
   `(let ~(reduce #(conj %1 %2 `(ns-resolve '~ns '~%2)) [] fns)
      ~@tests))
 
-(def sample-auth
-  {:id           "https://login.salesforce.com/id/1234",
-   :issued_at    "1367488271359",
-   :instance_url "https://na15.salesforce.com",
-   :signature    "SIG",
-   :access_token "ACCESS"})
-
 (deftest with-version-test
   (testing "should set +version+ to a given string"
     (is (= "26.0" (with-version "26.0" @+version+)))))
@@ -72,7 +65,9 @@
 
 (deftest test-soql-prepare
   (testing "should generate expected params "
-    (is (= {:method :get :url "https://salesforce.localhost/services/data/v39.0/query?q=SELECT+foo+from+Account" :headers expected-auth-header-from-well-formed-auth-token-mock}
+    (is (= {:method :get
+            :headers expected-auth-header-from-well-formed-auth-token-mock
+            :url "https://salesforce.localhost/services/data/v39.0/query?q=SELECT+foo+from+Account" }
            (soql-prepare "SELECT foo from Account" well-formed-auth-token-mock)))))
 
 ;; Private functions
@@ -101,7 +96,6 @@
 
 (with-private-fns [salesforce.core [parse-limit-info]]
   (deftest test-parse-limit-info
-
     (testing "extracts info"
       (is (= {:used 289725 :available 645000}
              (parse-limit-info "api-usage=289725/645000"))))))

--- a/test/salesforce/core_test.clj
+++ b/test/salesforce/core_test.clj
@@ -75,10 +75,52 @@
   (testing "response-shape"
     (is (= {:api-result {:a 1} :limit-info {:used 100 :available 555}}
            ; Note that if the none of the urls we give in a `with-fake-routes` block match what is given to the client, then the response is NOT mocked
-           ; and the client makes an actual call. Because we use host salesforce.localhost in the test, the request won't go anywhere if tht happens.
+           ; and the client makes an actual call. Because we use host salesforce.localhost in the test, the request won't go anywhere if that happens.
            (with-fake-routes
              {"https://salesforce.localhost/services/data/v39.0/query?q=SELECT+foo+from+Account" (fn [request] {:status 200 :headers {"Sforce-Limit-Info" "api-usage=100/555"} :body "{\"a\":1}"})}
              (soql! "SELECT foo from Account" well-formed-auth-token-mock))))))
+
+(def expected-all-versions-result
+  {:api-result [{:label "Winter '11", :url "/services/data/v20.0", :version "20.0"}
+                {:label "Spring '11", :url "/services/data/v21.0", :version "21.0"}
+                {:label "Summer '11", :url "/services/data/v22.0", :version "22.0"}
+                {:label "Winter '12", :url "/services/data/v23.0", :version "23.0"}
+                {:label "Spring '12", :url "/services/data/v24.0", :version "24.0"}
+                {:label "Summer '12", :url "/services/data/v25.0", :version "25.0"}
+                {:label "Winter '13", :url "/services/data/v26.0", :version "26.0"}
+                {:label "Spring '13", :url "/services/data/v27.0", :version "27.0"}
+                {:label "Summer '13", :url "/services/data/v28.0", :version "28.0"}
+                {:label "Winter '14", :url "/services/data/v29.0", :version "29.0"}
+                {:label "Spring '14", :url "/services/data/v30.0", :version "30.0"}
+                {:label "Summer '14", :url "/services/data/v31.0", :version "31.0"}
+                {:label "Winter '15", :url "/services/data/v32.0", :version "32.0"}
+                {:label "Spring '15", :url "/services/data/v33.0", :version "33.0"}
+                {:label "Summer '15", :url "/services/data/v34.0", :version "34.0"}
+                {:label "Winter '16", :url "/services/data/v35.0", :version "35.0"}
+                {:label "Spring '16", :url "/services/data/v36.0", :version "36.0"}
+                {:label "Summer '16", :url "/services/data/v37.0", :version "37.0"}
+                {:label "Winter '17", :url "/services/data/v38.0", :version "38.0"}
+                {:label "Spring '17", :url "/services/data/v39.0", :version "39.0"}
+                {:label "Summer '17", :url "/services/data/v40.0", :version "40.0"}
+                {:label "Winter '18", :url "/services/data/v41.0", :version "41.0"}
+                {:label "Spring ’18", :url "/services/data/v42.0", :version "42.0"}
+                {:label "Summer '18", :url "/services/data/v43.0", :version "43.0"}
+                {:label "Winter '19", :url "/services/data/v44.0", :version "44.0"}
+                {:label "Spring '19", :url "/services/data/v45.0", :version "45.0"}
+                {:label "Summer '19", :url "/services/data/v46.0", :version "46.0"}],
+   :limit-info {}})
+
+(deftest test-all-versions
+  (testing "handles request"
+    (is (= expected-all-versions-result (with-fake-routes
+                                          {"http://na1.salesforce.com/services/data/" (fn [request] {:status 200 :body "[{\"label\":\"Winter '11\",\"url\":\"/services/data/v20.0\",\"version\":\"20.0\"},{\"label\":\"Spring '11\",\"url\":\"/services/data/v21.0\",\"version\":\"21.0\"},{\"label\":\"Summer '11\",\"url\":\"/services/data/v22.0\",\"version\":\"22.0\"},{\"label\":\"Winter '12\",\"url\":\"/services/data/v23.0\",\"version\":\"23.0\"},{\"label\":\"Spring '12\",\"url\":\"/services/data/v24.0\",\"version\":\"24.0\"},{\"label\":\"Summer '12\",\"url\":\"/services/data/v25.0\",\"version\":\"25.0\"},{\"label\":\"Winter '13\",\"url\":\"/services/data/v26.0\",\"version\":\"26.0\"},{\"label\":\"Spring '13\",\"url\":\"/services/data/v27.0\",\"version\":\"27.0\"},{\"label\":\"Summer '13\",\"url\":\"/services/data/v28.0\",\"version\":\"28.0\"},{\"label\":\"Winter '14\",\"url\":\"/services/data/v29.0\",\"version\":\"29.0\"},{\"label\":\"Spring '14\",\"url\":\"/services/data/v30.0\",\"version\":\"30.0\"},{\"label\":\"Summer '14\",\"url\":\"/services/data/v31.0\",\"version\":\"31.0\"},{\"label\":\"Winter '15\",\"url\":\"/services/data/v32.0\",\"version\":\"32.0\"},{\"label\":\"Spring '15\",\"url\":\"/services/data/v33.0\",\"version\":\"33.0\"},{\"label\":\"Summer '15\",\"url\":\"/services/data/v34.0\",\"version\":\"34.0\"},{\"label\":\"Winter '16\",\"url\":\"/services/data/v35.0\",\"version\":\"35.0\"},{\"label\":\"Spring '16\",\"url\":\"/services/data/v36.0\",\"version\":\"36.0\"},{\"label\":\"Summer '16\",\"url\":\"/services/data/v37.0\",\"version\":\"37.0\"},{\"label\":\"Winter '17\",\"url\":\"/services/data/v38.0\",\"version\":\"38.0\"},{\"label\":\"Spring '17\",\"url\":\"/services/data/v39.0\",\"version\":\"39.0\"},{\"label\":\"Summer '17\",\"url\":\"/services/data/v40.0\",\"version\":\"40.0\"},{\"label\":\"Winter '18\",\"url\":\"/services/data/v41.0\",\"version\":\"41.0\"},{\"label\":\"Spring ’18\",\"url\":\"/services/data/v42.0\",\"version\":\"42.0\"},{\"label\":\"Summer '18\",\"url\":\"/services/data/v43.0\",\"version\":\"43.0\"},{\"label\":\"Winter '19\",\"url\":\"/services/data/v44.0\",\"version\":\"44.0\"},{\"label\":\"Spring '19\",\"url\":\"/services/data/v45.0\",\"version\":\"45.0\"},{\"label\":\"Summer '19\",\"url\":\"/services/data/v46.0\",\"version\":\"46.0\"}]"})}
+                                          (all-versions))))))
+
+(deftest test-latest-version
+  (testing "it extracts latest version from the all-versions response"
+    (is (= "46.0" (with-fake-routes
+                    {"http://na1.salesforce.com/services/data/" (fn [request] {:status 200 :body "[{\"label\":\"Winter '11\",\"url\":\"/services/data/v20.0\",\"version\":\"20.0\"},{\"label\":\"Spring '11\",\"url\":\"/services/data/v21.0\",\"version\":\"21.0\"},{\"label\":\"Summer '11\",\"url\":\"/services/data/v22.0\",\"version\":\"22.0\"},{\"label\":\"Winter '12\",\"url\":\"/services/data/v23.0\",\"version\":\"23.0\"},{\"label\":\"Spring '12\",\"url\":\"/services/data/v24.0\",\"version\":\"24.0\"},{\"label\":\"Summer '12\",\"url\":\"/services/data/v25.0\",\"version\":\"25.0\"},{\"label\":\"Winter '13\",\"url\":\"/services/data/v26.0\",\"version\":\"26.0\"},{\"label\":\"Spring '13\",\"url\":\"/services/data/v27.0\",\"version\":\"27.0\"},{\"label\":\"Summer '13\",\"url\":\"/services/data/v28.0\",\"version\":\"28.0\"},{\"label\":\"Winter '14\",\"url\":\"/services/data/v29.0\",\"version\":\"29.0\"},{\"label\":\"Spring '14\",\"url\":\"/services/data/v30.0\",\"version\":\"30.0\"},{\"label\":\"Summer '14\",\"url\":\"/services/data/v31.0\",\"version\":\"31.0\"},{\"label\":\"Winter '15\",\"url\":\"/services/data/v32.0\",\"version\":\"32.0\"},{\"label\":\"Spring '15\",\"url\":\"/services/data/v33.0\",\"version\":\"33.0\"},{\"label\":\"Summer '15\",\"url\":\"/services/data/v34.0\",\"version\":\"34.0\"},{\"label\":\"Winter '16\",\"url\":\"/services/data/v35.0\",\"version\":\"35.0\"},{\"label\":\"Spring '16\",\"url\":\"/services/data/v36.0\",\"version\":\"36.0\"},{\"label\":\"Summer '16\",\"url\":\"/services/data/v37.0\",\"version\":\"37.0\"},{\"label\":\"Winter '17\",\"url\":\"/services/data/v38.0\",\"version\":\"38.0\"},{\"label\":\"Spring '17\",\"url\":\"/services/data/v39.0\",\"version\":\"39.0\"},{\"label\":\"Summer '17\",\"url\":\"/services/data/v40.0\",\"version\":\"40.0\"},{\"label\":\"Winter '18\",\"url\":\"/services/data/v41.0\",\"version\":\"41.0\"},{\"label\":\"Spring ’18\",\"url\":\"/services/data/v42.0\",\"version\":\"42.0\"},{\"label\":\"Summer '18\",\"url\":\"/services/data/v43.0\",\"version\":\"43.0\"},{\"label\":\"Winter '19\",\"url\":\"/services/data/v44.0\",\"version\":\"44.0\"},{\"label\":\"Spring '19\",\"url\":\"/services/data/v45.0\",\"version\":\"45.0\"},{\"label\":\"Summer '19\",\"url\":\"/services/data/v46.0\",\"version\":\"46.0\"}]"})}
+                    (latest-version))))))
 
 ;; Private functions
 
@@ -89,23 +131,33 @@
       (let [url (gen-query-url "20.0" "SELECT name from Account")]
         (is (= url "/services/data/v20.0/query?q=SELECT+name+from+Account"))))))
 
-(with-private-fns [salesforce.core [prepare-request]]
-  (deftest test-prepare-request
+(with-private-fns [salesforce.core [prepare-authorized-request]]
+  (deftest test-prepare-authorized-request
     (testing "should generate expected params when no client params specified"
       (is (= {:method :get
               :url "https://salesforce.localhost/foo/bar/baz"
               :headers expected-auth-header-from-well-formed-auth-token-mock}
-             (prepare-request :get "/foo/bar/baz" well-formed-auth-token-mock)))))
+             (prepare-authorized-request :get "/foo/bar/baz" well-formed-auth-token-mock)))))
 
   (testing "should generate expected params when client params are specified"
     (is (= {:method :get
             :url "https://salesforce.localhost/foo/bar/baz"
             :headers expected-auth-header-from-well-formed-auth-token-mock
             :connection-timeout 5000}
-           (prepare-request :get "/foo/bar/baz" well-formed-auth-token-mock {:connection-timeout 5000})))))
+           (prepare-authorized-request :get "/foo/bar/baz" well-formed-auth-token-mock {:connection-timeout 5000})))))
 
 (with-private-fns [salesforce.core [parse-limit-info]]
   (deftest test-parse-limit-info
     (testing "extracts info"
       (is (= {:used 289725 :available 645000}
              (parse-limit-info "api-usage=289725/645000"))))))
+
+(with-private-fns [salesforce.core [prepare-public-request]]
+  (deftest prepare-public-request-test
+    (testing "should generate expected params when no client params given"
+      (is (= {:method :get :url "https://salesforce.localhost"}
+             (prepare-public-request :get "https://salesforce.localhost"))))
+
+    (testing "should generate expected params when client params are given"
+      (is (= {:method :get :url "https://salesforce.localhost" :connection-timeout 7000}
+             (prepare-public-request :get "https://salesforce.localhost" {:connection-timeout 7000}))))))

--- a/test/salesforce/core_test.clj
+++ b/test/salesforce/core_test.clj
@@ -74,3 +74,12 @@
       (let [url (gen-query-url "20.0" "SELECT name from Account")]
         (is (= url "/services/data/v20.0/query?q=SELECT+name+from+Account"))))))
 
+(with-private-fns [salesforce.core [prepare-request]]
+  (deftest test-prepare-request
+    (testing "should generate expected params"
+      (let [token {:instance_url "http://salesforce.localhost" :access_token "my_token"}]
+        (is (= {:method :get
+                :url "http://salesforce.localhost/foo/bar/baz"
+                :headers {"Authorization" "Bearer my_token"}}
+               (prepare-request :get "/foo/bar/baz" token)))))))
+

--- a/test/salesforce/core_test.clj
+++ b/test/salesforce/core_test.clj
@@ -99,3 +99,9 @@
             :connection-timeout 5000}
            (prepare-request :get "/foo/bar/baz" well-formed-auth-token-mock {:connection-timeout 5000})))))
 
+(with-private-fns [salesforce.core [parse-limit-info]]
+  (deftest test-parse-limit-info
+
+    (testing "extracts info"
+      (is (= {:used 289725 :available 645000}
+             (parse-limit-info "api-usage=289725/645000"))))))

--- a/test/salesforce/core_test.clj
+++ b/test/salesforce/core_test.clj
@@ -71,14 +71,14 @@
             :url "https://salesforce.localhost/services/data/v39.0/query?q=SELECT+foo+from+Account"}
            (soql-prepare "SELECT foo from Account" well-formed-auth-token-mock)))))
 
-(deftest test-soql!
+(deftest test-soql
   (testing "response-shape"
     (is (= {:api-result {:a 1} :limit-info {:used 100 :available 555}}
            ; Note that if the none of the urls we give in a `with-fake-routes` block match what is given to the client, then the response is NOT mocked
            ; and the client makes an actual call. Because we use host salesforce.localhost in the test, the request won't go anywhere if that happens.
            (with-fake-routes
              {"https://salesforce.localhost/services/data/v39.0/query?q=SELECT+foo+from+Account" (fn [request] {:status 200 :headers {"Sforce-Limit-Info" "api-usage=100/555"} :body "{\"a\":1}"})}
-             (soql! "SELECT foo from Account" well-formed-auth-token-mock))))))
+             (soql "SELECT foo from Account" well-formed-auth-token-mock))))))
 
 (def expected-all-versions-result
   {:api-result [{:label "Winter '11", :url "/services/data/v20.0", :version "20.0"}

--- a/test/salesforce/core_test.clj
+++ b/test/salesforce/core_test.clj
@@ -34,7 +34,7 @@
       {:form-params {:grant_type    "password"
                      :client_id     "my-ID"
                      :client_secret "my-SECRET"
-                     :format         "json",
+                     :format        "json",
                      :username      "my-USERNAME"
                      :password      "my-PASSWORDmy-TOKEN"}}
       (make-params-for-auth-request well-formed-auth-app-data nil))))
@@ -42,10 +42,10 @@
   (testing "accepts empty 2nd arg"
     (is
      (=
-      {:form-params {:grant_type "password"
+      {:form-params {:grant_type    "password"
                      :client_id     "my-ID"
                      :client_secret "my-SECRET"
-                     :format         "json",
+                     :format        "json",
                      :username      "my-USERNAME"
                      :password      "my-PASSWORDmy-TOKEN"}}
       (make-params-for-auth-request well-formed-auth-app-data {}))))
@@ -53,10 +53,10 @@
   (testing "includes all keys from 2nd arg when provided"
     (is
      (=
-      {:form-params                {:grant_type "password"
+      {:form-params                {:grant_type    "password"
                                     :client_id     "my-ID"
                                     :client_secret "my-SECRET"
-                                    :format         "json",
+                                    :format        "json",
                                     :username      "my-USERNAME"
                                     :password      "my-PASSWORDmy-TOKEN"}
        :connection-timeout         10
@@ -65,9 +65,8 @@
       (make-params-for-auth-request well-formed-auth-app-data
                                     {:connection-timeout 10 :connection-request-timeout 10 :foo 5})))))
 
-()
-
 ;; Private functions
+
 
 (with-private-fns [salesforce.core [gen-query-url]]
   (deftest gen-query-url-test

--- a/test/salesforce/core_test.clj
+++ b/test/salesforce/core_test.clj
@@ -25,46 +25,6 @@
    :password       "my-PASSWORD"
    :security-token "my-TOKEN"})
 
-(def well-formed-client-config-empty {})
-
-(deftest test-make-params-for-auth-request
-  (testing "accepts nil 2nd arg"
-    (is
-     (=
-      {:form-params {:grant_type    "password"
-                     :client_id     "my-ID"
-                     :client_secret "my-SECRET"
-                     :format        "json",
-                     :username      "my-USERNAME"
-                     :password      "my-PASSWORDmy-TOKEN"}}
-      (make-params-for-auth-request well-formed-auth-app-data nil))))
-
-  (testing "accepts empty 2nd arg"
-    (is
-     (=
-      {:form-params {:grant_type    "password"
-                     :client_id     "my-ID"
-                     :client_secret "my-SECRET"
-                     :format        "json",
-                     :username      "my-USERNAME"
-                     :password      "my-PASSWORDmy-TOKEN"}}
-      (make-params-for-auth-request well-formed-auth-app-data {}))))
-
-  (testing "includes all keys from 2nd arg when provided"
-    (is
-     (=
-      {:form-params                {:grant_type    "password"
-                                    :client_id     "my-ID"
-                                    :client_secret "my-SECRET"
-                                    :format        "json",
-                                    :username      "my-USERNAME"
-                                    :password      "my-PASSWORDmy-TOKEN"}
-       :connection-timeout         10
-       :connection-request-timeout 15
-       :foo                        5}
-      (make-params-for-auth-request well-formed-auth-app-data
-                                    {:connection-timeout 10 :connection-request-timeout 15 :foo 5})))))
-
 (def well-formed-auth-token-mock
   {:instance_url "https://salesforce.localhost" :access_token "my_token"})
 


### PR DESCRIPTION
This is a rather busy PR.

It does 5 main things:
1. Makes it possible to pass in http client config options to `auth!` and `soql`, such as timeouts or a connection manager. 
2. Stops swallowing exceptions that occur when making `soql` requests. (The pre-existing `request` function is the culprit.) This change exposes things like timeout exceptions so that they can be handled properly by a retry wrapper in application code. 
3. Improves testability of API operations by splitting them into prepare/perform steps. (See below for more detail.)
4. Gets the limit usage tracking code working. 
5. Changes the response shape for `auth!` and `soql!` to include the limit info in a map with the api result. 

To improve testability, we divide the http-client operations (for the ones we are planning to use in the immediate future) into 2 parts: 
1. A pure function: Prepare the request  as a map of data.
2. An impure function: Perform the request, which means sending the map of data to the clj-http client library, which makes the HTTP request. 

By splitting our operations into 2 parts, we can easily unit test the pure functions (aka the prepares) to make sure we are sending what we think we should be sending.  (Because we don't want to make real API requests in our tests, we can't verify that what we think we should be sending is correct.) 

## Out of scope
Changing all the API operations in core.clj to use the split approach and accept http client options. We can do those on an as-needed basis in future PRs. 

## Manual Testing:
```
> lein repl 

(def my-salesforce-config {"REDACTED"}

(use 'salesforce.core)

(def query "SELECT name from Account")

(def auth-result (auth! my-salesforce-config))
(def auth-token (:api-result auth-result))

(soql! query auth-token)

(read-limit-info)
```



